### PR TITLE
Fixed version from 1.0.0 to latest

### DIFF
--- a/buddhi/README.md
+++ b/buddhi/README.md
@@ -9,7 +9,7 @@ Responsibilities:
 ## Usage
 
 ```shell
-docker run --rm quay.io/3scale/perftest-toolkit:buddhi-v1.0.0 -h
+docker run --rm quay.io/3scale/perftest-toolkit:buddhi-latest -h
 usage: buddhi [options]
     -T, --testplan      load test definition key: ["saas", "onprem", "simple"]
     -I, --internal-api  backend internal api endpoint


### PR DESCRIPTION
It is just minor fix, but I suppose it should be 1.1.0 since it has been already tagged and docker image exists.