### PR TITLE
Version bump Hyperfoil to 0.11 to overcome a memory leak in a driver.

### DIFF
--- a/deployment/group_vars/all.yml
+++ b/deployment/group_vars/all.yml
@@ -13,4 +13,4 @@ hyperfoil_controller_group: hyperfoil_controller
 injector_hyperfoil_agent_threads: 4
 injector_hyperfoil_target_protocol: https
 injector_hyperfoil_target_port: 443
-hyperfoil_version: 0.9
+hyperfoil_version: 0.11

--- a/deployment/requirements.yaml
+++ b/deployment/requirements.yaml
@@ -1,6 +1,6 @@
 - src: hyperfoil.hyperfoil_setup
-  version: 0.9.1
+  version: 0.11
 - src: hyperfoil.hyperfoil_shutdown
-  version: 0.9.1
+  version: 0.11
 - src: hyperfoil.hyperfoil_test
-  version: 0.9.1
+  version: 0.11


### PR DESCRIPTION
This PR looks to bring in a fix for a memory leak.